### PR TITLE
Changed textbutton to inkwell in header button

### DIFF
--- a/lib/presentation/lp_header_appbar.dart
+++ b/lib/presentation/lp_header_appbar.dart
@@ -22,12 +22,10 @@ class HeaderAppBar extends StatelessWidget implements PreferredSizeWidget {
       title: Padding(
         padding: const EdgeInsets.all(16),
         child: OverflowBar(
-          alignment: MainAxisAlignment
-              .spaceBetween, 
+          alignment: MainAxisAlignment.spaceBetween,
           children: [
             Row(
-              mainAxisSize: MainAxisSize
-                  .min, 
+              mainAxisSize: MainAxisSize.min,
               children: [
                 SizedBox(
                   width: 36,
@@ -45,13 +43,17 @@ class HeaderAppBar extends StatelessWidget implements PreferredSizeWidget {
                 ),
               ],
             ),
-            TextButton(
-              onPressed: () {
+            InkWell(
+              onTap: () {
                 launchUrlString('https://ti.to/flutterninjas/tokyo-2025');
               },
-              child: const Text(
+              child: Text(
                 'Buy Ticket',
-                style: TextStyle(color: Colors.white),
+                style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                      fontSize: 16,
+                    ),
               ),
             ),
           ],


### PR DESCRIPTION
Somehow TextButton had padding, so I changed it to InkWell

|before|after|
|:-:|:-:|
|![IMG_D1BDC5E753D6-1](https://github.com/user-attachments/assets/44a1b378-8d1c-470c-a008-9861d0184b93)|![2](https://github.com/user-attachments/assets/e4b446cc-a995-4217-aa2c-7695c1a3a573)|